### PR TITLE
Added useNativeDriver: false to the params of Animated.timing

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,12 +71,14 @@ const EmojiBoard = ({
         if (showBoard) {
             Animated.timing(position, {
                 duration: 300,
-                toValue: 0
+                toValue: 0,
+                useNativeDriver: false
             }).start();
         } else {
             Animated.timing(position, {
                 duration: 300,
-                toValue: -animationOffset
+                toValue: -animationOffset,
+                useNativeDriver: false
             }).start();
         }
     }, [showBoard, position, animationOffset]);


### PR DESCRIPTION
This is to address the YellowBox warning for needing the useNativeDriver params. Due to native animation not supporting layout props, I set the parameter to be false.

https://github.com/facebook/react-native/issues/13150#issuecomment-289280995